### PR TITLE
Allowing for multiple s3 buckets

### DIFF
--- a/app/transfer_service/transfer_ready_validation.py
+++ b/app/transfer_service/transfer_ready_validation.py
@@ -10,7 +10,6 @@ def validate_json_schema(json_data):
     schemasdir = os.path.join(app_path, "schemas")
     
     logging.debug("Schemas dir: {}".format(schemasdir))
-    print("Schemas dir: {}".format(schemasdir))
     
     if json_data is None:
         raise Exception("Missing JSON data in validate_json_schema")

--- a/env-template.txt
+++ b/env-template.txt
@@ -18,10 +18,11 @@ TRANSFER_QUEUE_CONSUME_NAME=/queue/transfer-ready
 #Default to one hour
 MESSAGE_EXPIRATION_MS=3600000
 
-S3_BUCKET_NAME=XXX
 #Read-Write Credentials
-AWS_ACCESS_KEY_ID=XXX
-AWS_SECRET_ACCESS_KEY=XXX
+DVN_AWS_ACCESS_KEY_ID=XXX
+DVN_AWS_SECRET_ACCESS_KEY=XXX
+EPADD_AWS_ACCESS_KEY_ID=XXX
+EPADD_AWS_SECRET_ACCESS_KEY=XXX
 
 #The filename of the file that contains
 #the hash of each the supplied files (for validation)
@@ -30,3 +31,6 @@ SUPPLIED_HASH_MAPPING_FILENAME=XXX
 CHECKSUM_ALGORITHM=md5
 #List of required filenames separated by commas.  Use relative paths
 REQUIRED_UNZIPPED_FILES=XXX
+
+##For testing
+S3_BUCKET_NAME=XXX

--- a/tests/integration/test_transfer.py
+++ b/tests/integration/test_transfer.py
@@ -7,40 +7,98 @@ from botocore.client import ClientError
 
 logging.basicConfig(format='%(message)s')
 
-s3_bucket=os.getenv("S3_BUCKET_NAME", "dataverse-export-dev")
 s3_path="doi-12-3456-transfer-service-test"
     
-def test_perform_transfer():
+def test_perform_dvn_transfer():
     '''Tests to see if data can be transferred to the dropbox'''
+    s3 = boto3.resource('s3',
+                aws_access_key_id=os.getenv("DVN_AWS_ACCESS_KEY_ID"),
+                aws_secret_access_key=os.getenv("DVN_AWS_SECRET_ACCESS_KEY"),
+                region_name="us-east-1")
+      
+    s3_bucket="dataverse-export-dev"
     #Upload the data to s3 to test the dropbox transfer
-    transfer_helper.upload_sample_data(s3_bucket, s3_path)
-     
-    assert transfer_service.path_exists(s3_bucket, s3_path)
-     
+    transfer_helper.upload_sample_data(s3, s3_bucket, s3_path)
+       
+    assert transfer_service.path_exists(s3, s3_bucket, s3_path)
+       
     dropbox_path="/home/appuser/local/dropbox"
     dest_path = os.path.join(dropbox_path, os.path.basename(s3_path))
-     
-    transfer_service.perform_transfer(s3_bucket, s3_path, dest_path)
-     
+       
+    transfer_service.perform_transfer(s3, s3_bucket, s3_path, dest_path)
+       
     assert os.path.exists(dest_path)
-     
+       
     #cleanup the data that was moved to the dropbox
     transfer_helper.cleanup_dropbox(dest_path)
-    
-def test_cleanup_s3():
+     
+def test_perform_epadd_transfer():
+    '''Tests to see if data can be transferred to the dropbox'''
+      
+    s3 = boto3.resource('s3',
+            aws_access_key_id=os.getenv("EPADD_AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("EPADD_AWS_SECRET_ACCESS_KEY"),
+            region_name="us-east-1")
+     
+    s3_bucket="epadd-export-dev" 
+    #Upload the data to s3 to test the dropbox transfer
+    transfer_helper.upload_sample_data(s3, s3_bucket, s3_path)
+       
+    assert transfer_service.path_exists(s3, s3_bucket, s3_path)
+       
+    dropbox_path="/home/appuser/local/dropbox"
+    dest_path = os.path.join(dropbox_path, os.path.basename(s3_path))
+       
+    transfer_service.perform_transfer(s3, s3_bucket, s3_path, dest_path)
+       
+    assert os.path.exists(dest_path)
+       
+    #cleanup the data that was moved to the dropbox
+    transfer_helper.cleanup_dropbox(dest_path)
+     
+def test_dvn_cleanup_s3():
     '''Tests to make sure the s3 cleanup method works'''
     #Upload the data to s3 to test the dropbox transfer
-    transfer_helper.upload_sample_data(s3_bucket, s3_path)
+    s3 = boto3.resource('s3',
+            aws_access_key_id=os.getenv("DVN_AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("DVN_AWS_SECRET_ACCESS_KEY"),
+            region_name="us-east-1")
     
-    assert transfer_service.path_exists(s3_bucket, s3_path)
-    
-    transfer_service.cleanup_s3(s3_bucket, s3_path)
-    
-    assert not transfer_service.path_exists(s3_bucket, s3_path)
-    
+    s3_bucket="dataverse-export-dev"
+    transfer_helper.upload_sample_data(s3, s3_bucket, s3_path)
+     
+    assert transfer_service.path_exists(s3, s3_bucket, s3_path)
+     
+    transfer_service.cleanup_s3(s3, s3_bucket, s3_path)
+     
+    assert not transfer_service.path_exists(s3, s3_bucket, s3_path)
+     
+def test_epadd_cleanup_s3():
+    '''Tests to make sure the s3 cleanup method works'''
+     
+    s3 = boto3.resource('s3',
+            aws_access_key_id=os.getenv("EPADD_AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("EPADD_AWS_SECRET_ACCESS_KEY"),
+            region_name="us-east-1")
+     
+    s3_bucket="epadd-export-dev" 
+    #Upload the data to s3 to test the dropbox transfer
+    transfer_helper.upload_sample_data(s3, s3_bucket, s3_path)
+     
+    assert transfer_service.path_exists(s3, s3_bucket, s3_path)
+     
+    transfer_service.cleanup_s3(s3, s3_bucket, s3_path)
+     
+    assert not transfer_service.path_exists(s3, s3_bucket, s3_path)
+     
 def test_cleanup_s3_failure():
     with pytest.raises(ClientError):
         '''Tests to make sure the s3 cleanup method fails when the bucket doesn't exists'''
-        transfer_service.cleanup_s3("non-existant-bucket", "non-existant-path")
+         
+        s3 = boto3.resource('s3',
+            aws_access_key_id=os.getenv("DVN_AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("DVN_AWS_SECRET_ACCESS_KEY"),
+            region_name="us-east-1")
+        transfer_service.cleanup_s3(s3, "non-existant-bucket", "non-existant-path")
 
 

--- a/tests/integration/transfer_helper.py
+++ b/tests/integration/transfer_helper.py
@@ -1,21 +1,18 @@
 import os, os.path, shutil, boto3
 from botocore.exceptions import ClientError
 
-def upload_sample_data(s3_bucket, s3_path):
+def upload_sample_data(s3, s3_bucket, s3_path):
     '''Uploaods the sample data if it doesn't exist in the bucket alreaady'''
-    s3_connect = boto3.client('s3', "us-east-1")
-
     try:
-        s3_connect.head_object(Bucket=s3_bucket, Key=s3_path)
-    except ClientError as e:
+        s3.Object(s3_bucket, s3_path).load()
+    except ClientError:
         #Upload the files if the directory doesn't exist
         sample_data_path = os.path.join("/home/appuser/tests/data", s3_path)
         for filename in os.listdir(sample_data_path):
     
             file_key_name = s3_path + '/' + filename
             local_name = sample_data_path + '/' + filename
-            print('uploading {} '.format(local_name))
-            s3_connect.upload_file(local_name, s3_bucket, file_key_name)
+            s3.meta.client.upload_file(local_name, s3_bucket, file_key_name)
   
             
 def cleanup_dropbox(dir_path):


### PR DESCRIPTION
Allows for multiple s3 buckets

**GitHub Issue**: https://github.com/harvard-lts/epadd/issues/113

# How should this be tested?

1. Clone the repo
2. Checkout the branch multi-use
3. Copy the env-template.txt to .env
4. In the .env, set` DVN_AWS_ACCESS_KEY_ID, DVN_AWS_SECRET_ACCESS_KEY, EPADD_AWS_ACCESS_KEY_ID, EPADD_AWS_SECRET_ACCESS_KEY` values to the dev rw values for the s3 buckets found in LPE.
5. tart up the docker container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
6. Exec into the container: `docker exec -it hdc3a-transfer-service bash`
7. Run the command `pytest`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? yes

