### PR TITLE
Use Etags to validate transfer of zipped epadd exports

### DIFF
--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -55,20 +55,8 @@ def transfer_data(message_data):
             logging.exception("Transfer Validation Failed with Exception {}".format(str(e)))
             raise e
 
-    elif application_name == "ePADD":
-
-        try:
-            #Type ValidationReturnValue
-            validation_retval : transfer_validation.ValidationReturnValue  = transfer_validation.validate_transfer(zipextractionpath, dest_path)
-            #Validate transfer
-            if not validation_retval.isvalid:
-                msg = "Transfer Validation Failed Gracefully:"
-                msg = msg + "\n" + ','.join(validation_retval.get_error_messages())
-                logging.error(msg)
-                raise ValidationException(msg)
-        except ValidationException as e:
-            logging.exception("Transfer Validation Failed with Exception {}".format(str(e)))
-            raise e
+    # TODO: Validate ePADD export
+    # elif application_name == "ePADD":
     
     #Notify transfer success
     transfer_status = mqutils.TransferStatus(message_data["package_id"], "success", dest_path)

--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -35,8 +35,15 @@ def transfer_data(message_data):
            
     #Transfer
     perform_transfer(s3, s3_bucket_name, s3_path, dest_path)
+    zipextractionpath = None
+    if ('application_name' in message_data):
+        if (message_data['application_name'] == "Dataverse"):
+            zipextractionpath = unzip_transfer(dest_path)
+        else:
+            zipextractionpath = ""    
+    else:
+         raise TransferException("The application_name parameter does not exist in the message body {}.".format(message_data)) 
     
-    zipextractionpath = unzip_transfer(dest_path)
     
     try:   
         #Type ValidationReturnValue

--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -55,9 +55,21 @@ def transfer_data(message_data):
             logging.exception("Transfer Validation Failed with Exception {}".format(str(e)))
             raise e
 
-    # TODO: Validate ePADD export
-    # elif application_name == "ePADD":
-    
+    elif application_name == "ePADD":
+
+        try:
+            # Type ValidationReturnValue
+            validation_retval: transfer_validation.ValidationReturnValue = transfer_validation.validate_zipped_transfer(s3, message_data)
+            # Validate transfer
+            if not validation_retval.isvalid:
+                msg = "Transfer Validation Failed Gracefully:"
+                msg = msg + "\n" + ','.join(validation_retval.get_error_messages())
+                logging.error(msg)
+                raise ValidationException(msg)
+        except ValidationException as e:
+            logging.exception("Transfer Validation Failed with Exception {}".format(str(e)))
+            raise e
+
     #Notify transfer success
     transfer_status = mqutils.TransferStatus(message_data["package_id"], "success", dest_path)
     mqutils.notify_transfer_status_message(transfer_status)

--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -12,6 +12,7 @@ logging.basicConfig(filename=logfile, level=loglevel, format="%(asctime)s:%(leve
 
 def transfer_data(message_data):
     s3 = None
+    s3_client = None
     application_name = ""
     if ('application_name' in message_data):
         application_name = message_data['application_name']
@@ -22,6 +23,10 @@ def transfer_data(message_data):
                 region_name="us-east-1")
         else:
             s3 = boto3.resource('s3',
+                aws_access_key_id=os.getenv("EPADD_AWS_ACCESS_KEY_ID"),
+                aws_secret_access_key=os.getenv("EPADD_AWS_SECRET_ACCESS_KEY"),
+                region_name="us-east-1")
+            s3_client = boto3.client('s3',
                 aws_access_key_id=os.getenv("EPADD_AWS_ACCESS_KEY_ID"),
                 aws_secret_access_key=os.getenv("EPADD_AWS_SECRET_ACCESS_KEY"),
                 region_name="us-east-1")
@@ -59,7 +64,7 @@ def transfer_data(message_data):
 
         try:
             # Type ValidationReturnValue
-            validation_retval: transfer_validation.ValidationReturnValue = transfer_validation.validate_zipped_transfer(s3, message_data)
+            validation_retval: transfer_validation.ValidationReturnValue = transfer_validation.validate_zipped_transfer(s3_client, message_data)
             # Validate transfer
             if not validation_retval.isvalid:
                 msg = "Transfer Validation Failed Gracefully:"

--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -22,6 +22,9 @@ def transfer_data(message_data):
                 aws_secret_access_key=os.getenv("DVN_AWS_SECRET_ACCESS_KEY"),
                 region_name="us-east-1")
         else:
+            # TODO: Make creation of s3_client configurable to make adding non-Amazon S3 implementations more flexible
+            # TODO: Refactor code to use only boto client instead of boto3 resource
+            # JIRA Ticket: https://jira.huit.harvard.edu/browse/LTSEPADD-28
             s3 = boto3.resource('s3',
                 aws_access_key_id=os.getenv("EPADD_AWS_ACCESS_KEY_ID"),
                 aws_secret_access_key=os.getenv("EPADD_AWS_SECRET_ACCESS_KEY"),

--- a/app/transfer_service/transfer_validation.py
+++ b/app/transfer_service/transfer_validation.py
@@ -64,14 +64,7 @@ def validate_zip_checksum(s3_client, s3_bucket_name, s3_path, data_directory_nam
     logging.debug("Etag of " + os.path.join(data_directory_name, filename) + "is: " + s3_zip_hash)
 
     # Get dropbox zip hash - calculate etag
-    dropbox_zip_hash = None
-    md5_digests = []
-    partsize = 8388608  # aws_cli/boto3
-    with open(os.path.join(data_directory_name, filename), 'rb') as f:
-        for chunk in iter(lambda: f.read(partsize), b''):
-            md5_digests.append(hashlib.md5(chunk).digest())
-    dropbox_zip_hash = hashlib.md5(b''.join(md5_digests)).hexdigest() + '-' + str(len(md5_digests))
-
+    dropbox_zip_hash = calculate_etag(data_directory_name, filename)
     logging.debug("local etag of " + os.path.join(data_directory_name, filename) + "is: " + s3_zip_hash)
 
     # Compare
@@ -181,3 +174,11 @@ def calculate_checksum(filepath):
         return hashlib.sha512(open(filepath,'rb').read()).hexdigest()
     #default to md5
     return hashlib.md5(open(filepath,'rb').read()).hexdigest()
+
+def calculate_etag(filepath, filename):
+    md5_digests = []
+    partsize = 8388608  # aws_cli/boto3
+    with open(os.path.join(filepath, filename), 'rb') as f:
+        for chunk in iter(lambda: f.read(partsize), b''):
+            md5_digests.append(hashlib.md5(chunk).digest())
+    return hashlib.md5(b''.join(md5_digests)).hexdigest() + '-' + str(len(md5_digests))

--- a/app/transfer_service/transfer_validation.py
+++ b/app/transfer_service/transfer_validation.py
@@ -16,7 +16,22 @@ class ValidationReturnValue:
         return self.isvalid
     
     def get_error_messages(self):
-        return self.errormessages    
+        return self.errormessages
+
+
+def validate_zipped_transfer(s3, message_data):
+    '''Validates the data that was transferred by checking for:
+    1. The required files in the destination dir
+    2. The hash of zip in s3 against the actual zip'''
+    s3_bucket_name = message_data['s3_bucket_name']
+    s3_path = message_data['s3_path']
+    data_directory_name = os.path.join(message_data['destination_path'], message_data['package_id'])
+
+    retval = validate_required_zipped_file(data_directory_name)
+    if retval.isvalid():
+        retval = validate_zip_checksum(s3, s3_bucket_name, s3_path, data_directory_name)
+
+    return retval
 
 def validate_transfer(unzipped_data_direcory, data_directory_name):
     '''Validates the data that was transferred by checking for:
@@ -28,6 +43,43 @@ def validate_transfer(unzipped_data_direcory, data_directory_name):
     if retval.isvalid and _does_data_exist(unzipped_data_direcory):
         retval = validate_mapping(unzipped_data_direcory)
             
+    return retval
+
+
+def validate_zip_checksum(s3, s3_bucket_name, s3_path, data_directory_name):
+    '''Validates the zip that was transferred by checking the
+    zip hash against the hash in s3'''
+    isvalid = True
+    incorrecthashes = []
+    filename = ""
+
+    # Get file
+    for file in os.listdir(data_directory_name):
+        if file.endswith(".zip"):
+            filename = file
+
+    # Get s3 zip hash
+    bucket = s3.Bucket(s3_bucket_name)
+    s3_zip_hash = bucket.get_key(os.join(s3_path, filename)).etag[1:-1]
+
+    # Get dropbox zip hash
+    dropbox_zip_hash = ""
+    md5_hash = hashlib.md5()
+    with open(filename, "rb") as f:
+        # Read and update hash in chunks of 4K
+        for byte_block in iter(lambda: f.read(4096), b""):
+            md5_hash.update(byte_block)
+        dropbox_zip_hash = md5_hash.hexdigest()
+
+    # Compare
+    if dropbox_zip_hash != s3_zip_hash:
+        isvalid = False
+        msg = "The md5 hash of zip file {} in s3 of {} did not match the md5 of transferred file {}".format(filename, s3_zip_hash, dropbox_zip_hash)
+        incorrecthashes.append(msg)
+        logging.error(msg)
+
+    retval = ValidationReturnValue(isvalid, incorrecthashes)
+
     return retval
 
 def validate_mapping(unzipped_data_direcory):
@@ -70,6 +122,24 @@ def validate_mapping(unzipped_data_direcory):
     
     return retval
 
+
+def validate_required_zipped_file(data_directory_name):
+    """Validates that the zip file exist in the transferred dir"""
+
+    zip_exist = False
+    errormessages = []
+    for file in os.listdir(data_directory_name):
+        if file.endswith(".zip"):
+            zip_exist = True
+
+    if not zip_exist:
+        msg = "Required file {} is missing from unzipped bag".format(data_directory_name)
+        errormessages.append(msg)
+        logging.error(msg)
+
+    retval = ValidationReturnValue(zip_exist, errormessages)
+
+    return retval
                  
 def validate_required_unzipped_files(unzipped_data_direcory):
     '''Validates that the list of required files provided in the .env

--- a/app/transfer_service/transfer_validation.py
+++ b/app/transfer_service/transfer_validation.py
@@ -66,7 +66,7 @@ def validate_zip_checksum(s3_client, s3_bucket_name, s3_path, data_directory_nam
     # Get dropbox zip hash - calculate etag
     dropbox_zip_hash = None
     md5_digests = []
-    partsize = 8388608, # aws_cli/boto3
+    partsize = 8388608  # aws_cli/boto3
     with open(os.path.join(data_directory_name, filename), 'rb') as f:
         for chunk in iter(lambda: f.read(partsize), b''):
             md5_digests.append(hashlib.md5(chunk).digest())


### PR DESCRIPTION
**Use Etags to validate transfer of zipped epadd exports**
* * *

**GitHub Issue**: [LTSEPADD-15](https://jira.huit.harvard.edu/browse/LTSEPADD-15)

# What does this Pull Request do?
This PR includes validation of the transfer of zipped epadd exports. Since all the contents are zipped, we cannot use the manifest.txt to verify the checksums of each file, so this allows us to verify using the checksum of the zip itself.

# How should this be tested?

1. Make sure dev transfer queue and aws credentials are set in your .env (can be found on lastpass)
2. build and run image with `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
3. exec into the container with `docker exec -it dais-transfer-service bash`
4. Run `pytest`
5. Confirm all tests pass
6. Stop container locally
7. Deploy to dev through trial
8. curl http://ltsds-cloud-dev-1.lib.harvard.edu:10586/testExport
9. Confirm a successful ingest into DRS

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
@ives1227 @michael-lts 
