### PR TITLE
Etd 258

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ RUN apt-get update && apt-get install -y libpq-dev gcc python-dev supervisor ngi
   pip install --upgrade --force-reinstall -r /tmp/requirements.txt -i https://pypi.org/simple/ --extra-index-url https://test.pypi.org/simple/ &&\
   groupadd -r -g 55020 appuser && \
   groupadd -r -g 4177 epadd_secure && \
+  groupadd -r -g 55031 etdadm && \
+  groupadd -r -g 1636 appcommon && \
   useradd -u 55020 -g 55020 --create-home appuser && \
-  usermod -a -G 4177 appuser
+  usermod -a -G 4177 appuser && \
+  usermod -a -G 1636 appuser && \
+  usermod -a -G 55031 appuser
 
 # Supervisor to run and manage multiple apps in the same container
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -1,4 +1,5 @@
-import boto3, os, os.path, logging, zipfile, glob, shutil
+import boto3, os, os.path, logging, zipfile, glob
+import shutil
 from botocore.exceptions import ClientError
 import transfer_service.transfer_ready_validation as transfer_ready_validation
 from transfer_service.transferexception import TransferException 

--- a/app/transfer_service/transfer_service.py
+++ b/app/transfer_service/transfer_service.py
@@ -1,4 +1,4 @@
-import boto3, os, os.path, logging, zipfile, glob
+import boto3, os, os.path, logging, zipfile, glob, shutil
 from botocore.exceptions import ClientError
 import transfer_service.transfer_ready_validation as transfer_ready_validation
 from transfer_service.transferexception import TransferException 
@@ -128,7 +128,26 @@ def perform_transfer(s3, s3_bucket_name, s3_path, dropbox_dir):
             continue
         logger.debug("Downloading {} to {}".format(obj.key, target))
         bucket.download_file(obj.key, target)
-        
+
+       
+def perform_fs_transfer(file_name, file_path, dropbox_dir):
+    """
+    Copy the contents of a folder directory
+    Args:
+        file_name: the name of the file
+        s3_path: the folder path in the s3 bucket
+        dropbox_dir: an absolute directory path in the local file system
+    """
+    
+    logger.debug("Transferring {}/{} to {}".format(file_name, file_path, dropbox_dir))
+
+    source = os.path.join(file_path, file_name)    
+    target = os.path.join(dropbox_dir, file_name)
+    if not os.path.exists(os.path.dirname(target)):
+        os.makedirs(os.path.dirname(target))
+    logger.debug("Copying {} to {}".format(source, target))
+    shutil.copy(source, target)
+
 def unzip_transfer(fulldestpath):
     '''Unzips the transferred zipfile'''
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       # App
       - './:/home/appuser'
-      - '/Users/michaelvandermillen/etd_data:/home/appuser/etd_data'
+      - './etd_data:/home/appuser/etd_data'
       # Logs
       - './logs:/home/appuser/logs'
     env_file:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       # App
       - './:/home/appuser'
+      - '/Users/michaelvandermillen/etd_data:/home/appuser/etd_data'
       # Logs
       - './logs:/home/appuser/logs'
     env_file:

--- a/tests/integration/test_transfer.py
+++ b/tests/integration/test_transfer.py
@@ -4,6 +4,7 @@ import transfer_service.transfer_service as transfer_service
 import transfer_helper
 from transfer_service.transferexception import TransferException
 import transfer_service.transfer_validation as transfer_validation
+import shutil
 from botocore.client import ClientError
 
 logging.basicConfig(format='%(message)s')
@@ -64,7 +65,24 @@ def test_perform_epadd_transfer():
     #cleanup the data that was moved to the dropbox
     transfer_helper.cleanup_dropbox(dest_path)
 
-     
+
+def test_perform_fs_transfer():
+    file_name = "submission-test.zip"
+    sample_data_path = os.path.join("/home/appuser/tests/data/proquest-test", file_name)
+    etd_storage_dir = "/home/appuser/etd_data/in/proquest_test/"
+    if not os.path.exists(os.path.dirname(etd_storage_dir)):
+        os.makedirs(os.path.dirname(etd_storage_dir))
+    etd_storage_path = os.path.join(etd_storage_dir, file_name)
+    shutil.copyfile(sample_data_path, etd_storage_path)
+    dropbox_path="/home/appuser/local/dropbox"
+    dest_path = os.path.join(dropbox_path, "proquest-test")
+    transfer_service.perform_fs_transfer(file_name, etd_storage_dir, dest_path)
+    assert os.path.exists(f"{dest_path}/{file_name}")
+    #clean up
+    os.remove(etd_storage_path)
+    transfer_helper.cleanup_dropbox(dest_path)
+
+
 def test_dvn_cleanup_s3():
     '''Tests to make sure the s3 cleanup method works'''
     #Upload the data to s3 to test the dropbox transfer

--- a/tests/unit/test_transfer_service.py
+++ b/tests/unit/test_transfer_service.py
@@ -46,3 +46,14 @@ def test_validate_with_no_data():
     assert transfer_validation.validate_transfer(zipextractionpath, os.path.join(data_path, doi_no_data_path))
     
     cleanup_extraction(os.path.join(data_path, doi_no_data_path, "extracted"))
+
+def test_perform_fs_transfer():
+    file_name = "submission_993578.zip"
+    filepath = f"{data_path}/proquest2023080116-993578-gsd"
+    dropbox = f"{data_path}/dropbox"
+    if not os.path.exists(os.path.dirname(dropbox)):
+        os.makedirs(os.path.dirname(dropbox))
+    transfer_service.perform_fs_transfer(file_name, filepath, dropbox)
+    assert os.path.isfile(f"{dropbox}/{file_name}")
+    #clean up
+    os.remove(f"{dropbox}/{file_name}")

--- a/tests/unit/test_transfer_service.py
+++ b/tests/unit/test_transfer_service.py
@@ -54,6 +54,6 @@ def test_perform_fs_transfer():
     if not os.path.exists(os.path.dirname(dropbox)):
         os.makedirs(os.path.dirname(dropbox))
     transfer_service.perform_fs_transfer(file_name, filepath, dropbox)
-    assert os.path.isfile(f"{dropbox}/{file_name}")
+    assert os.path.exists(f"{dropbox}/{file_name}")
     #clean up
     os.remove(f"{dropbox}/{file_name}")

--- a/tests/unit/test_transfer_service.py
+++ b/tests/unit/test_transfer_service.py
@@ -48,8 +48,8 @@ def test_validate_with_no_data():
     cleanup_extraction(os.path.join(data_path, doi_no_data_path, "extracted"))
 
 def test_perform_fs_transfer():
-    file_name = "submission_993578.zip"
-    filepath = f"{data_path}/proquest2023080116-993578-gsd"
+    file_name = "submission-test.zip"
+    filepath = f"{data_path}/proquest-test"
     dropbox = f"{data_path}/dropbox"
     if not os.path.exists(os.path.dirname(dropbox)):
         os.makedirs(os.path.dirname(dropbox))


### PR DESCRIPTION
**FS to dropbox transfer.**
* * *

**Jira Issue**: [(link)](https://jira.huit.harvard.edu/browse/ETD-258)

# What does this Pull Request do?
This PR contains a function to transfer a file from the file system to a dropbox, the first use case for which is ETDs. (This adds to the existing functions that pull from s3 and transfer to a dropbox).
Unlike the s3 to dropbox transfer, this fs to fs transfer does not remove the file from the source fs, it will have its own retention and cleanup (and the file could also be needed for alma ingest, as there is no defined order for drs and alma. Permissions were added to the Dockerfile for accessing the etd dir, and volumes mapping was added to DAIS-IF (currently only deployed to dev).

# How should this be tested?

Pull this branch local and build (see readme)
Tweak docker-compose-local.yml as needed for shared dir
Exec into container (see readme)
Run pytest
Deploy to dev (along with DAIS-IF), exec into container and run pytest (done)
# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Y
- integration tests? Y

